### PR TITLE
+ modal wrap, no-scrolling for open nav menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -403,6 +403,20 @@ and (min-width: 551px) {
     header .x-icon {
         width: 38px;
     }
+    
+    .modal {
+        background-color: rgba(0,0,0,0.4);
+        width: 100vh;
+        height: 100vh;
+        position: fixed;
+        z-index: 100;
+        left: 0;
+        top: 0;
+    }
+    
+    .no-scroll {
+        overflow-y: hidden;
+    }
 }
 
 /* Header and Footer

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     </head>
     <body>
         <!-- // Intro  -->
+        <div class="modal-wrap"></div>
         <header id="about">
             <a class="menu-open"><img class="bars-icon" src="images/menu-bars-icon.png"/></a>
             <a class="menu-close"><img class="x-icon" src="images/x-icon.png"/></a>
@@ -18,7 +19,7 @@
                 <a href="#work">Work Experience</a>
                 <a href="#education">Education</a>
                 <a href="#contact">Contact</a>
-                <a  class="btn download" href="MaizeResume.pdf" target="_blank" ><span>Resume PDF</span></a>
+                <a  class="btn download" href="MaizeResume.pdf" target="_blank" >Resume PDF</a>
             </nav>
             <div class="section-content-wrap">
                 <h1>Gianni Maize</h1>
@@ -111,5 +112,4 @@
         </footer>
     </body>
     <script src="js/main.js"></script>
-
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,7 @@
+var html = document.querySelector("html");
+var modalWrap = document.querySelector(".modal-wrap");
 var navMenu = document.querySelector("header nav");
-var navMenuLinks = document.querySelectorAll("header nav a")
+var navMenuLinks = document.querySelectorAll("header nav a");
 var menuBars = document.querySelector("header .bars-icon");
 var menuX = document.querySelector("header .x-icon");
 
@@ -10,8 +12,11 @@ for (var i = 0; i < navMenuLinks.length; i++) {
 };
 menuBars.onclick = openNavMenu;
 menuX.onclick = closeNavMenu;
+modalWrap.onclick = closeNavMenu;
 
 function openNavMenu() {
+    html.classList.add("no-scroll");
+    modalWrap.classList.add("modal");
     navMenu.classList.add("visible");
     menuBars.classList.add("hidden");
     menuX.classList.add("visible");
@@ -26,6 +31,8 @@ function closeNavMenu() {
     menuX.classList.add("hidden");
     menuBars.classList.add("visible");
     
+    html.classList.remove("no-scroll");
+    modalWrap.classList.remove("modal");
     navMenu.classList.remove("visible");
     menuX.classList.remove("visible");
     menuBars.classList.remove("hidden");


### PR DESCRIPTION
When nav menu is open, page overflow is hidden, modal background is
shown, and clicking outside of nav menu closes menu